### PR TITLE
Feat/max length

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Where `options` can be populated with any of the following properties:
 |`position`|`top`|The position of the toolbar in relation to the text container.|`top` or `bottom`|
 |`content`|`null`|The content that will be loaded into the text container upon loading.|`plain text` and/or `html text` as a `string`|
 |`placeholder`|`Insert text...`|The text that will display when the rich editor is unfocused in the empty state.|`string`|
+|`maxLength`|`undefined`|The maximum number of available characters, if set.| `number` |
 |`showToolbar`|`always`|How the toolbar should be shown or hidden based on user actions |`always`, `onHover`, or `onSelect`|
 |`autoFocus`|`false`|To focus on the text component upon init.|`boolean`|
 |`font: {`</br>`family,`<br>`size,`</br>`color,`</br>`faces`</br>`};`| `family: Arial`</br>`size: 12px`</br>`color: #626272`</br>`faces: null` | To set what the font variables will be in the rich text editor. | `family: string`<br>`size: string`</br>`color: string`</br>`faces: FontFace[]`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@teamhive/rich-text-editor",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Rich text editor web component. Built with Stencil.",
     "homepage": "https://github.com/TeamHive/rich-text-editor",
     "repository": {

--- a/src/components/rich-text/rich-text.component.tsx
+++ b/src/components/rich-text/rich-text.component.tsx
@@ -198,6 +198,7 @@ export class HiveRichTextComponent {
         else if (
             !isSpecialKey(event.keyCode)            // allow non-typing keys
             && !isKey(event.keyCode, 'Backspace')   // allow backspacing
+            && this.iframe.contentDocument.getSelection().getRangeAt(0).toString().length === 0 // allow typing over (replacing) selected text
             && (this.options.maxLength && this.options.maxLength <= (event.target as HTMLElement).innerText.length)
         ) {
             event.preventDefault();
@@ -243,11 +244,13 @@ export class HiveRichTextComponent {
 
                 const range = this.iframe.contentDocument.getSelection().getRangeAt(0);
 
+                // max length + length of section being replaced - current length
+                const availableLength = this.options.maxLength + range.toString().length - length;
+
                 // delete current range contents
                 range.deleteContents();
 
                 // add as much of clipboard data as can fit
-                const availableLength = this.options.maxLength + range.toString().length - length;
                 const textNode = this.iframe.contentDocument.createTextNode(
                     text.slice(0, availableLength > 0 ? availableLength : 0)
                 );

--- a/src/components/rich-text/rich-text.component.tsx
+++ b/src/components/rich-text/rich-text.component.tsx
@@ -195,9 +195,11 @@ export class HiveRichTextComponent {
 
         // prevent entering past the maxLength
         else if (
-            !isSpecialKey(event.keyCode)            // allow non-typing keys
-            || !isKey(event.keyCode, 'Backspace')   // allow backspacing
-            && this.options.maxLength <= (event.target as HTMLElement).innerText.length
+            (
+                !isSpecialKey(event.keyCode)            // allow non-typing keys
+                || !isKey(event.keyCode, 'Backspace')   // allow backspacing
+            )
+            && (this.options.maxLength && this.options.maxLength <= (event.target as HTMLElement).innerText.length)
         ) {
             event.preventDefault();
         }

--- a/src/components/rich-text/rich-text.component.tsx
+++ b/src/components/rich-text/rich-text.component.tsx
@@ -115,6 +115,7 @@ export class HiveRichTextComponent {
         this.iframe.contentDocument['onkeydown'] = (event: KeyboardEvent) => this.keydown(event);
         this.iframe.contentDocument['onmousedown'] = (event: MouseEvent) => this.mousedown(event);
         this.iframe.contentDocument['touchstart'] = (event: MouseEvent) => this.touchstart(event);
+        this.iframe.contentDocument['onpaste'] = (event: ClipboardEvent) => this.paste(event);
 
         this.iframe.contentDocument.body['onfocus'] = () => {
             this.focused = true;
@@ -228,6 +229,34 @@ export class HiveRichTextComponent {
 
     touchstart(event: MouseEvent) {
         this.anchorEvent = event;
+    }
+
+    paste(event: ClipboardEvent) {
+        if (this.iframe) {
+           const length = (event.target as HTMLElement).innerText.length;
+           const data = event.clipboardData.getData('text/plain');
+
+           // if data will not fit into available space,
+           // trim it down to fit and perform custom paste
+            if (this.options.maxLength && (this.options.maxLength < (length + data.length))) {
+
+                // max length + length of section being replaced - current length
+                const availableLength = this.options.maxLength
+                    + this.iframe.contentDocument.getSelection().getRangeAt(0).toString().length
+                    - length;
+
+                // delete current selection
+                this.iframe.contentDocument.getSelection().deleteFromDocument();
+
+                // add as much of clipboard data as can fit
+                this.iframe.contentDocument.createTextNode(
+                    data.slice(0, availableLength > 0 ? availableLength : 0)
+                );
+
+                // stop default paste
+                event.preventDefault();
+           }
+        }
     }
 
     checkForEmpty() {

--- a/src/components/rich-text/rich-text.component.tsx
+++ b/src/components/rich-text/rich-text.component.tsx
@@ -52,8 +52,7 @@ export class HiveRichTextComponent {
 
     // customize
     @Prop() options: RichTextEditorOptions = {
-        placeholder: 'Insert text...',
-        maxLength: 20
+        placeholder: 'Insert text...'
     };
 
     // states

--- a/src/components/rich-text/rich-text.component.tsx
+++ b/src/components/rich-text/rich-text.component.tsx
@@ -52,7 +52,8 @@ export class HiveRichTextComponent {
 
     // customize
     @Prop() options: RichTextEditorOptions = {
-        placeholder: 'Insert text...'
+        placeholder: 'Insert text...',
+        maxLength: 20
     };
 
     // states
@@ -195,10 +196,8 @@ export class HiveRichTextComponent {
 
         // prevent entering past the maxLength
         else if (
-            (
-                !isSpecialKey(event.keyCode)            // allow non-typing keys
-                || !isKey(event.keyCode, 'Backspace')   // allow backspacing
-            )
+            !isSpecialKey(event.keyCode)            // allow non-typing keys
+            && !isKey(event.keyCode, 'Backspace')   // allow backspacing
             && (this.options.maxLength && this.options.maxLength <= (event.target as HTMLElement).innerText.length)
         ) {
             event.preventDefault();

--- a/src/components/rich-text/rich-text.component.tsx
+++ b/src/components/rich-text/rich-text.component.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, h, Method, Prop, State } from '@stencil/core';
-import { EditorUtils, allowedConfig, GetFontFaces } from '../../utils/';
+import { EditorUtils, allowedConfig, GetFontFaces, isOSKey, keys, isKey, isSpecialKey } from '../../utils/';
 import { RichTextEditorOptions } from './rich-text.interface';
 import { Icons } from '../icons/icons';
 
@@ -144,22 +144,22 @@ export class HiveRichTextComponent {
     }
 
     keydown(event: KeyboardEvent) {
-        if (event.keyCode === 91 || event.keyCode === 93) { // keycode control button
+        if (isOSKey(event.keyCode)) { // keycode control button
             this.keycodeDown = event.keyCode;
-        } else if (this.keycodeDown === 91 || this.keycodeDown === 93) {
+        } else if (isOSKey(this.keycodeDown)) {
             switch (event.keyCode) {
-                case 66:
+                case keys['KeyB']:
                     this.toggleActiveState('bold');
                     break;
-                case 73:
+                case keys['KeyI']:
                     this.toggleActiveState('italic');
                     break;
-                case 85:
+                case keys['KeyU']:
                     this.style('underline');
                     this.toggleActiveState('underline');
                     break;
             }
-        } else if (event.keyCode === 13) {
+        } else if (isKey(event.keyCode, 'Enter')) {
             const thisListItem = this.iframe.contentDocument.getSelection().focusNode.parentElement.closest('li') || this.iframe.contentDocument.getSelection().focusNode;
 
             const list = thisListItem.parentElement;
@@ -172,7 +172,7 @@ export class HiveRichTextComponent {
                     }
                 }
         }
-        else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+        else if (isKey(event.keyCode, ['ArrowUp', 'ArrowDown'])) {
 
             // Handle the cursor position if the list is at the beginning or the end of the document
             const thisListItem = this.iframe.contentDocument.getSelection().focusNode.parentElement.closest('li');
@@ -180,16 +180,25 @@ export class HiveRichTextComponent {
                 const list = thisListItem.parentElement;
 
                 if (list != null) {
-                    if (event.key === 'ArrowUp' && list.children[0] === thisListItem && list.previousSibling == null) {
+                    if (isKey(event.keyCode, 'ArrowUp') && list.children[0] === thisListItem && list.previousSibling == null) {
                         const startBreak = this.iframe.contentDocument.createElement('br');
                         this.iframe.contentDocument.body.insertBefore(startBreak, list);
                     }
-                    else if (event.key === 'ArrowDown' && list.children[list.childElementCount - 1] === thisListItem && list.nextSibling == null) {
+                    else if (isKey(event.keyCode, 'ArrowDown') && list.children[list.childElementCount - 1] === thisListItem && list.nextSibling == null) {
                         const endBreak = this.iframe.contentDocument.createElement('br');
                         this.iframe.contentDocument.body.appendChild(endBreak);
                     }
                 }
             }
+        }
+
+        // prevent entering past the maxLength
+        else if (
+            !isSpecialKey(event.keyCode)            // allow non-typing keys
+            || !isKey(event.keyCode, 'Backspace')   // allow backspacing
+            && this.options.maxLength <= (event.target as HTMLElement).innerText.length
+        ) {
+            event.preventDefault();
         }
     }
 
@@ -209,7 +218,7 @@ export class HiveRichTextComponent {
             }
         }
 
-        if (event.keyCode === 91 || this.keycodeDown === 93) {
+        if (isKey(event.keyCode, 'OSLeft') || isKey(this.keycodeDown, 'OSRight')) {
             this.keycodeDown = null;
         }
 

--- a/src/components/rich-text/rich-text.interface.ts
+++ b/src/components/rich-text/rich-text.interface.ts
@@ -8,6 +8,8 @@ export interface RichTextEditorOptions {
 
     placeholder?: string; // what to display when the text box is empty
 
+    maxLength?: number // total number of available plain-text characters
+
     showToolbar?:
     'always' | // always show the toolbar. Default behavior
     'onHover' | // only have the toolbar appear when you are hovering over the text container

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './allowed-config';
 export * from './editor.utils';
 export * from './font-face.utils';
+export * from './keyboard.utils';

--- a/src/utils/keyboard.utils.ts
+++ b/src/utils/keyboard.utils.ts
@@ -1,0 +1,50 @@
+export const keys: { [name: string]: number } = {
+    'Backspace': 8,
+    'Enter': 13,
+    'Shift': 16,
+    'Ctrl': 17,
+    'Alt': 18,
+    'Delete': 46,
+    'ArrowLeft': 37,
+    'ArrowUp': 38,
+    'ArrowRight': 39,
+    'ArrowDown': 40,
+    'KeyB': 66,
+    'KeyI': 73,
+    'KeyU': 85,
+    'OSLeft': 91,
+    'OSRight': 93
+}
+
+export const specialKeys: { [code: number]: boolean } = {
+
+    // control
+    [keys['Shift']]: true,
+    [keys['Ctrl']]: true,
+    [keys['Alt']]: true,
+    [keys['Delete']]: true,
+
+    // navigation
+    [keys['ArrowUp']]: true,
+    [keys['ArrowDown']]: true,
+    [keys['ArrowLeft']]: true,
+    [keys['ArrowRight']]: true,
+
+    // meta
+    [keys['OSLeft']]: true,
+    [keys['OSRight']]: true,
+};
+
+export const isKey = (keyCode: number, keyName: string | string[]) => {
+    return Array.isArray(keyName)
+        ? keyName.some(name => keys[name] === keyCode)
+        : keys[keyName] === keyCode;
+}
+
+export const isSpecialKey = (keyCode: number) => {
+    return specialKeys[keyCode];
+};
+
+export const isOSKey = (keyCode: number) => {
+    return isKey(keyCode, ['OSLeft', 'OSRight'])
+}


### PR DESCRIPTION
## TeamHive/rich-text-editor v2.1.0

### What's New:
- A `maxLength` property to the `RichTextEditorOptions` options config
    * maxLength is of type `number`
    * character limit respected by Keyboard and Clipboard events

### What's Changed:
- No breaking changes, or changes to current use cases
- Keyboard events made clearer via a new keyboard.utils.ts

### Implementation
```ts
options: RichTextEditorOptions = {
    ⋮
    maxLength: 20
};
````

### Demos
#### Keyboard (typing)
![2020-04-10 20 18 36](https://user-images.githubusercontent.com/35740174/78988900-1a3bcd80-7b6d-11ea-8307-b268bd5ecb46.gif)

#### Clipboard (pasting)
![2020-04-10 20 26 10](https://user-images.githubusercontent.com/35740174/78988928-29228000-7b6d-11ea-81c7-2a1dff2611f8.gif)

