### PR TITLE
Fix(rte): Pointer events only occur when toolbar is shown now

### DIFF
--- a/src/components/rich-text/rich-text.component.scss
+++ b/src/components/rich-text/rich-text.component.scss
@@ -59,9 +59,11 @@
 
         &.selection {
             opacity: 0;
+            pointer-events: none;
 
             &.show {
                 opacity: 1;
+                pointer-events: auto;
             }
         }
 


### PR DESCRIPTION
Only allows pointer events if the toolbar is shown, left default state alone in case there is no hidden instance.